### PR TITLE
chore(api): unify HTTP codes and JSON responses via Http helper

### DIFF
--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -1,5 +1,5 @@
 <?php
-namespace Controllers; use Base; use Models\UserModel; use Services\AuthService;
+namespace Controllers; use Base; use Models\UserModel; use Services\AuthService; use Services\Http; 
 
 class AuthController {
   private UserModel $users;
@@ -12,15 +12,16 @@ class AuthController {
     $email = strtolower(trim($input['email'] ?? ''));
     $pass = (string)($input['password'] ?? '');
     if (!filter_var($email, FILTER_VALIDATE_EMAIL) || strlen($pass) < 6) {
-      http_response_code(422);
-      echo json_encode(['error'=>'email/password invalid']); return;
+      Http::error(422, 'validation failed', 'Invalid email or weak password');
+      return;
     }
     if ($this->users->findByEmail($email)) {
-      http_response_code(409); echo json_encode(['error'=>'email exists']); return;
+      Http::error(409, 'conflict', 'Email already registered');
+      return;
     }
     $user = $this->users->create($email, password_hash($pass, PASSWORD_DEFAULT));
     $token = AuthService::tokenFor((int)$user['id']);
-    echo json_encode(['token'=>$token,'user'=>$user]);
+    Http::ok(['token'=>$token,'user'=>$user]);
   }
 
   public function login() {
@@ -29,10 +30,11 @@ class AuthController {
     $pass = (string)($input['password'] ?? '');
     $row = (new UserModel(Base::instance()->get('DB')))->findByEmail($email);
     if (!$row || !password_verify($pass, $row['password_hash'])) {
-      http_response_code(401); echo json_encode(['error'=>'invalid credentials']); return;
+      Http::error(401, 'unauthorized', 'Invalid credentials');
+      return;
     }
     $user = ['id'=>$row['id'],'email'=>$row['email'],'created_at'=>$row['created_at']];
     $token = AuthService::tokenFor((int)$row['id']);
-    echo json_encode(['token'=>$token,'user'=>$user]);
+    Http::ok(['token'=>$token,'user'=>$user]);
   }
 }

--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -1,5 +1,9 @@
 <?php
-namespace Controllers; use Base; use Models\UserModel; use Services\AuthService; use App\Services\Http; 
+namespace Controllers;
+use Base;
+use Models\UserModel;
+use Services\AuthService;
+use Services\Http;
 
 class AuthController {
   private UserModel $users;

--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -11,6 +11,7 @@ class AuthController {
     $input = json_decode(file_get_contents('php://input'), true) ?? [];
     $email = strtolower(trim($input['email'] ?? ''));
     $pass = (string)($input['password'] ?? '');
+    
     if (!filter_var($email, FILTER_VALIDATE_EMAIL) || strlen($pass) < 6) {
       Http::error(422, 'validation failed', 'Invalid email or weak password');
       return;
@@ -21,7 +22,7 @@ class AuthController {
     }
     $user = $this->users->create($email, password_hash($pass, PASSWORD_DEFAULT));
     $token = AuthService::tokenFor((int)$user['id']);
-    Http::ok(['token'=>$token,'user'=>$user]);
+    Http::created(['user'=>$user]);
   }
 
   public function login() {
@@ -29,6 +30,7 @@ class AuthController {
     $email = strtolower(trim($input['email'] ?? ''));
     $pass = (string)($input['password'] ?? '');
     $row = (new UserModel(Base::instance()->get('DB')))->findByEmail($email);
+
     if (!$row || !password_verify($pass, $row['password_hash'])) {
       Http::error(401, 'unauthorized', 'Invalid credentials');
       return;

--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -22,7 +22,7 @@ class AuthController {
     }
     $user = $this->users->create($email, password_hash($pass, PASSWORD_DEFAULT));
     $token = AuthService::tokenFor((int)$user['id']);
-    Http::created(['user'=>$user]);
+    Http::created(['token'=>$token, 'user'=>$user]);
   }
 
   public function login() {

--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -1,5 +1,5 @@
 <?php
-namespace Controllers; use Base; use Models\UserModel; use Services\AuthService; use Services\Http; 
+namespace Controllers; use Base; use Models\UserModel; use Services\AuthService; use App\Services\Http; 
 
 class AuthController {
   private UserModel $users;

--- a/app/Controllers/NoteController.php
+++ b/app/Controllers/NoteController.php
@@ -3,7 +3,7 @@ namespace Controllers;
 use Base;
 use Models\NoteModel;
 use Services\AuthService;
-use App\Services\Http;
+use Services\Http;
 
 class NoteController {
   private NoteModel $notes; private ?int $userId = null;

--- a/app/Controllers/NoteController.php
+++ b/app/Controllers/NoteController.php
@@ -3,7 +3,7 @@ namespace Controllers;
 use Base;
 use Models\NoteModel;
 use Services\AuthService;
-use Services\Http;
+use App\Services\Http;
 
 class NoteController {
   private NoteModel $notes; private ?int $userId = null;

--- a/app/Controllers/NoteController.php
+++ b/app/Controllers/NoteController.php
@@ -19,27 +19,27 @@ class NoteController {
     $f3 = Base::instance();
     $limit = (int)($f3->get('GET.limit') ?? 50);
     $offset= (int)($f3->get('GET.offset') ?? 0);
-    echo json_encode($this->notes->allByUser($this->userId,$limit,$offset));
+    Http::ok($this->notes->allByUser($this->userId,$limit,$offset));
   }
   public function show($f3, $params) {
     $note = $this->notes->find($this->userId, (int)$params['id']);
-    if (!$note) { http_response_code(404); echo json_encode(['error'=>'not found']); return; }
-    echo json_encode($note);
+    if (!$note) { Http::error(404, 'not found', 'Note not found'); return; }
+    Http::ok($note);
   }
   public function store() {
     $in = json_decode(file_get_contents('php://input'), true) ?? [];
-    if (!isset($in['title']) || trim($in['title'])==='') { http_response_code(422); echo json_encode(['error'=>'title required']); return; }
-    echo json_encode($this->notes->create($this->userId, $in));
+    if (!isset($in['title']) || trim($in['title'])==='') { Http::error(422, 'validation failed', 'Title is required'); return; }
+    Http::created($this->notes->create($this->userId, $in));
   }
   public function update($f3, $params) {
     $in = json_decode(file_get_contents('php://input'), true) ?? [];
     $note = $this->notes->update($this->userId, (int)$params['id'], $in);
-    if (!$note) { http_response_code(404); echo json_encode(['error'=>'not found']); return; }
-    echo json_encode($note);
+    if (!$note) { Http::error(404, 'not found', 'Note not found'); return; }
+    Http::ok($note);
   }
   public function destroy($f3, $params) {
     $ok = $this->notes->delete($this->userId, (int)$params['id']);
-    if (!$ok) { http_response_code(404); echo json_encode(['error'=>'not found']); return; }
-    echo json_encode(['deleted'=>true]);
+    if (!$ok) { Http::error(404, 'not found', 'Note not found'); return; }
+    Http::ok(['deleted'=>true]);
   }
 }

--- a/app/Controllers/NoteController.php
+++ b/app/Controllers/NoteController.php
@@ -1,5 +1,9 @@
 <?php
-namespace Controllers; use Base; use Models\NoteModel; use Services\AuthService;
+namespace Controllers;
+use Base;
+use Models\NoteModel;
+use Services\AuthService;
+use Services\Http;
 
 class NoteController {
   private NoteModel $notes; private ?int $userId = null;
@@ -8,7 +12,7 @@ class NoteController {
   // Hook appelé avant chaque action du contrôleur
   public function beforeroute() {
     $this->userId = AuthService::userIdOrNull();
-    if (!$this->userId) { http_response_code(401); echo json_encode(['error'=>'unauthorized']); exit; }
+    if (!$this->userId) { Http::error(401, 'unauthorized', 'Token missing or invalid'); exit; }
   }
 
   public function index() {

--- a/app/Services/Http.php
+++ b/app/Services/Http.php
@@ -1,0 +1,25 @@
+<?php
+namespace Services;
+
+final class Http {
+    public static function ok($data): void {
+        http_response_code(200);
+        header('Content-Type: application/json');
+        echo json_encode($data);
+    }
+
+    public static function created($data): void {
+        http_response_code(201);
+        header('Content-Type: application/json');
+        echo json_encode($data);
+    }
+
+    public static function error(int $code, string $error, string $message = ''): void {
+        http_response_code($code);
+        header('Content-Type: application/json');
+        echo json_encode([
+            'error' => $error,
+            'message' => $message
+        ]);
+    }
+}

--- a/app/Services/Http.php
+++ b/app/Services/Http.php
@@ -1,5 +1,5 @@
 <?php
-namespace App\Services;
+namespace Services;
 
 final class Http {
     public static function ok($data): void {

--- a/app/Services/Http.php
+++ b/app/Services/Http.php
@@ -1,5 +1,5 @@
 <?php
-namespace Services;
+namespace App\Services;
 
 final class Http {
     public static function ok($data): void {


### PR DESCRIPTION
# Description

This PR refactors **AuthController** and **NoteController** to use a centralized `Http` helper for consistent HTTP status codes and JSON responses.

### Changes
- Added `app/Services/Http.php` with `ok()`, `created()`, and `error()` methods.
- Updated `AuthController`:
  - `register`: returns 201 on success, 409 if email already exists.
  - `login`: returns 200 on success, 401 if credentials are invalid.
- Updated `NoteController`:
  - `index`, `show`, `update`, `destroy`: return 200 on success.
  - `store`: returns 201 on success, 422 if validation fails.
  - 404 responses when resource not found.
  - 401 responses when token missing or invalid.
- Ensured all responses include `Content-Type: application/json`.

## Checklist
- [x] Centralized HTTP responses via `Http` helper.
- [x] Consistent use of status codes (200/201/401/404/409/422).
- [x] Controllers updated accordingly.
- [x] Manual curl tests performed for success and error cases.

## Notes
Merging this PR will close the task **`chore/http-codes-and-errors`**.
